### PR TITLE
Fixed filter logic for landingpages

### DIFF
--- a/app/code/community/Hackathon/Layeredlanding/Model/Layeredlanding.php
+++ b/app/code/community/Hackathon/Layeredlanding/Model/Layeredlanding.php
@@ -37,6 +37,14 @@ class Hackathon_Layeredlanding_Model_Layeredlanding extends Mage_Core_Model_Abst
 			}
         }
 
+        $resource = Mage::getModel('core/resource');
+        $db = $resource->getConnection('core_write');
+
+        $attributes = $db->fetchPairs('SELECT attribute_id,value FROM layeredlanding_attributes WHERE layeredlanding_id = ?', array($this->getId()));
+        if($attributes) {
+            $this->setData('layered_attributes', $attributes);
+        }
+
         return $this;
     }
 

--- a/app/design/frontend/base/default/layout/layeredlanding.xml
+++ b/app/design/frontend/base/default/layout/layeredlanding.xml
@@ -5,6 +5,11 @@
             <block type="layeredlanding/canonical" name="layeredlanding.canonical" after="-" template="layeredlanding/canonical.phtml"/>
         </reference>
         <reference name="left">
+            <reference name="catalog.leftnav">
+                <action method="setTemplate">
+                    <template>layeredlanding/catalog/layer/view.phtml</template>
+                </action>
+            </reference>
             <block type="layeredlanding/leftnav" name="layeredlanding.leftnav" after="-">
                 <action method="setTemplate" ifconfig="catalog/frontend/layeredlanding_show_leftnav_menu">
                     <template>layeredlanding/leftnav.phtml</template>

--- a/app/design/frontend/base/default/template/layeredlanding/catalog/layer/state.phtml
+++ b/app/design/frontend/base/default/template/layeredlanding/catalog/layer/state.phtml
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magentocommerce.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magentocommerce.com for more information.
+ *
+ * @category    design
+ * @package     base_default
+ * @copyright   Copyright (c) 2013 Magento Inc. (http://www.magentocommerce.com)
+ * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+?>
+<?php
+/**
+ * Category layered navigation state
+ *
+ * @see Mage_Catalog_Block_Layer_State
+ */
+?>
+<?php $_filters = $this->getActiveFilters() ?>
+<?php
+$landingpage = Mage::registry('current_landingpage');
+$layeredAttributes = ($landingpage ? $landingpage->getLayeredAttributes() : array());
+?>
+<?php if(!empty($_filters)): ?>
+<div class="currently">
+    <p class="block-subtitle"><?php echo $this->__('Currently Shopping by:') ?></p>
+    <ol>
+    <?php foreach ($_filters as $_filter): ?>
+        <li>
+            <span class="label"><?php echo $this->__($_filter->getName()) ?>:</span> <span class="value"><?php echo $this->stripTags($_filter->getLabel()) ?></span>
+            <?php
+                $clearLinkUrl = $_filter->getClearLinkUrl();
+                if ($clearLinkUrl):
+            ?>
+                <a  class="btn-previous" href="<?php echo $_filter->getRemoveUrl() ?>" title="<?php echo $this->__('Previous') ?>"><?php echo $this->__('Previous') ?></a>
+                <?php if(!in_array($_filter->getFilter()->getAttributeModel()->getId(), array_keys($layeredAttributes))): ?>
+                    <a  class="btn-remove" title="<?php echo $this->escapeHtml($_filter->getFilter()->getClearLinkText()) ?>" href="<?php echo $clearLinkUrl ?>"><?php echo $this->escapeHtml($_filter->getFilter()->getClearLinkText()) ?></a>
+                <?php endif; ?>
+            <?php elseif(!in_array($_filter->getFilter()->getAttributeModel()->getId(), array_keys($layeredAttributes))): ?>
+                <a  class="btn-remove" href="<?php echo $_filter->getRemoveUrl() ?>" title="<?php echo $this->__('Remove This Item') ?>"><?php echo $this->__('Remove This Item') ?></a>
+            <?php endif; ?>
+        </li>
+    <?php endforeach; ?>
+    </ol>
+</div>
+<?php endif; ?>

--- a/app/design/frontend/base/default/template/layeredlanding/catalog/layer/view.phtml
+++ b/app/design/frontend/base/default/template/layeredlanding/catalog/layer/view.phtml
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Magento
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE_AFL.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@magentocommerce.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Magento to newer
+ * versions in the future. If you wish to customize Magento for your
+ * needs please refer to http://www.magentocommerce.com for more information.
+ *
+ * @category    design
+ * @package     base_default
+ * @copyright   Copyright (c) 2013 Magento Inc. (http://www.magentocommerce.com)
+ * @license     http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+?>
+<?php
+/**
+ * Category layered navigation
+ *
+ * @see Mage_Catalog_Block_Layer_View
+ */
+?>
+<?php if($this->canShowBlock()): ?>
+<?php
+$landingpage = Mage::registry('current_landingpage');
+$layeredAttributes = ($landingpage ? $landingpage->getLayeredAttributes() : array());
+?>
+<div class="block block-layered-nav">
+    <div class="block-title">
+        <strong><span><?php echo $this->__('Shop By') ?></span></strong>
+    </div>
+    <div class="block-content">
+        <?php echo $this->getStateHtml() ?>
+        <?php if ($_filters = $this->getLayer()->getState()->getFilters()): ?>
+            <?php if($landingpage && count($_filters) > count($layeredAttributes)): ?>
+                <div class="actions"><a href="<?php echo Mage::getBaseUrl() . $landingpage->getPageUrl(); ?>"><?php echo $this->__('Clear All') ?></a></div>
+            <?php elseif(!$landingpage): ?>
+                <div class="actions"><a href="<?php echo $this->getClearUrl() ?>"><?php echo $this->__('Clear All') ?></a></div>
+            <?php endif; ?>
+        <?php endif; ?>
+        <?php if($this->canShowOptions()): ?>
+            <p class="block-subtitle"><?php echo $this->__('Shopping Options') ?></p>
+            <dl id="narrow-by-list">
+                <?php $_filters = $this->getFilters() ?>
+                <?php foreach ($_filters as $_filter): ?>
+                <?php if($_filter->getItemsCount()): ?>
+                    <dt><?php echo $this->__($_filter->getName()) ?></dt>
+                    <dd><?php echo $_filter->getHtml() ?></dd>
+                <?php endif; ?>
+                <?php endforeach; ?>
+            </dl>
+            <script type="text/javascript">decorateDataList('narrow-by-list')</script>
+        <?php endif; ?>
+    </div>
+</div>
+<?php endif; ?>


### PR DESCRIPTION
The filter logic in the layered navigation block was incorrect for landingpages. For example, it gave you the option to remove a filter option, even though that filter was created for this landingpage and therefore could not be removed. Clicking the link would effectively mean a refresh, creating the illusion the filter was removed.

This commit fixes that; it removes the 'Remove filter' link for attributes that are defined within the landingpage configuration. It also removes the 'Clear All' link when there are no extra filters set (on top of the landingpage attribute filters). In case there are extra filters, the 'Clear All' link points to the landingpage URL instead of the URL of the first category chosen in the landingpage configuration.

To achieve this, the attribute filters that are set in the landingpage configuration are now added to the 'current_landingpage' registry item so they can be retrieved and compared in the template file.

Also, my editor apparently fixed some indentation.