### PR TITLE
removed unnecessary extends clauses, fixes #26

### DIFF
--- a/app/code/community/Hackathon/Layeredlanding/Model/Options/Attributes.php
+++ b/app/code/community/Hackathon/Layeredlanding/Model/Options/Attributes.php
@@ -1,6 +1,6 @@
 <?php
  
-class Hackathon_Layeredlanding_Model_Options_Attributes extends Mage_Core_Model_Abstract
+class Hackathon_Layeredlanding_Model_Options_Attributes
 {
 
     public function toOptionArray()

--- a/app/code/community/Hackathon/Layeredlanding/Model/Options/Boolean.php
+++ b/app/code/community/Hackathon/Layeredlanding/Model/Options/Boolean.php
@@ -1,6 +1,6 @@
 <?php
 
-class Hackathon_Layeredlanding_Model_Options_Boolean extends Mage_Page_Model_Source_Layout
+class Hackathon_Layeredlanding_Model_Options_Boolean
 {
 
     public function toOptionArray()

--- a/app/code/community/Hackathon/Layeredlanding/Model/Options/Categories.php
+++ b/app/code/community/Hackathon/Layeredlanding/Model/Options/Categories.php
@@ -1,6 +1,6 @@
 <?php
 
-class Hackathon_Layeredlanding_Model_Options_Categories extends Mage_Core_Model_Abstract
+class Hackathon_Layeredlanding_Model_Options_Categories
 {
 
     public function toOptionArray()

--- a/app/code/community/Hackathon/Layeredlanding/Model/Options/Layout.php
+++ b/app/code/community/Hackathon/Layeredlanding/Model/Options/Layout.php
@@ -1,6 +1,6 @@
 <?php
 
-class Hackathon_Layeredlanding_Model_Options_Layout extends Mage_Page_Model_Source_Layout
+class Hackathon_Layeredlanding_Model_Options_Layout
 {
 
     public function toOptionArray()

--- a/app/code/community/Hackathon/Layeredlanding/Model/Options/Layout.php
+++ b/app/code/community/Hackathon/Layeredlanding/Model/Options/Layout.php
@@ -1,11 +1,11 @@
 <?php
 
-class Hackathon_Layeredlanding_Model_Options_Layout
+class Hackathon_Layeredlanding_Model_Options_Layout extends Mage_Page_Model_Source_Layout
 {
 
-    public function toOptionArray()
+    public function toOptionArray($withEmpty = false)
     {
-        $options = parent::toOptionArray();
+        $options = parent::toOptionArray($withEmpty);
 		
 		array_unshift($options, array('value'=>'', 'label'=>Mage::helper('layeredlanding')->__('Inherit Template')));
 


### PR DESCRIPTION
These source models do not need to extend from any other model. The only method, which is used, is `toOptionArray` and this is implemented in the class itself.